### PR TITLE
JWT Sessions

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -1,4 +1,4 @@
-XapiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   creationTimestamp: null

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@angular/platform-browser": "~12.0.4",
         "@angular/platform-browser-dynamic": "~12.0.4",
         "@angular/router": "~12.0.4",
+        "@auth0/angular-jwt": "^5.0.2",
         "iframe-resizer": "^4.3.2",
         "rxjs": "~6.6.0",
         "tslib": "^2.1.0",
@@ -458,6 +459,17 @@
         "@angular/core": "12.0.5",
         "@angular/platform-browser": "12.0.5",
         "rxjs": "^6.5.3"
+      }
+    },
+    "node_modules/@auth0/angular-jwt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@auth0/angular-jwt/-/angular-jwt-5.0.2.tgz",
+      "integrity": "sha512-rSamC9mu+gUxoR86AXcIo+KD7xRIro+/iu1F2Ld85YAZEVKlpB5vYG+g0yGaEOqjtQWP/i0H6fi6XMGPVHSYYQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=9.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -16425,6 +16437,14 @@
       "integrity": "sha512-2jiaT+OxCmJbeJ0MTPmIHBsTFLysenvPZteozYsjcmUo9mOzJHAjqHLJvTC+Ri+E9xvnplh+8BPETRleV1pAFw==",
       "requires": {
         "tslib": "^2.1.0"
+      }
+    },
+    "@auth0/angular-jwt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@auth0/angular-jwt/-/angular-jwt-5.0.2.tgz",
+      "integrity": "sha512-rSamC9mu+gUxoR86AXcIo+KD7xRIro+/iu1F2Ld85YAZEVKlpB5vYG+g0yGaEOqjtQWP/i0H6fi6XMGPVHSYYQ==",
+      "requires": {
+        "tslib": "^2.0.0"
       }
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@angular/platform-browser": "~12.0.4",
     "@angular/platform-browser-dynamic": "~12.0.4",
     "@angular/router": "~12.0.4",
+    "@auth0/angular-jwt": "^5.0.2",
     "iframe-resizer": "^4.3.2",
     "rxjs": "~6.6.0",
     "tslib": "^2.1.0",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<div class="wrapper">
+<div class="wrapper" *ngIf="sessionToken">
   <div class="page-header">
     <div> REDACT FEED </div>
   </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<div class="wrapper" *ngIf="sessionToken">
+<div class="wrapper">
   <div class="page-header">
     <div> REDACT FEED </div>
   </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,13 @@
-import { AfterViewInit, Component, ContentChild, HostListener, OnInit, ViewChild} from '@angular/core';
+import { Component, HostListener, OnInit, ViewChild} from '@angular/core';
 import { FeedComponent } from './components/feed/feed/feed.component';
 import { NewPostComponent } from './components/new-post/new-post.component';
-import { HostSessionService } from './services/host-session.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent implements OnInit, AfterViewInit {
+export class AppComponent implements OnInit {
   
   @ViewChild(FeedComponent)
   public feedComponent!: FeedComponent;
@@ -17,20 +16,10 @@ export class AppComponent implements OnInit, AfterViewInit {
   public newPostComponent!: NewPostComponent;
 
   title = 'redact-feed';
-  sessionToken = localStorage.getItem('feed.redact.sessionAuthorizationToken');
-  
-  constructor(private hostSessionService: HostSessionService) {}
 
-  ngOnInit(): void {
-    if (this.sessionToken == null) {
-      this.hostSessionService.getSessionToken().then(result => {
-        this.sessionToken = result;
-      });
-    }
-  }
+  constructor() {}
 
-  ngAfterViewInit(): void {
-  }
+  ngOnInit(): void {}
 
   @HostListener('window:message', ['$event'])
   PostSubmittedEvent(event: MessageEvent) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { AfterViewInit, Component, ContentChild, HostListener, OnInit, ViewChild} from '@angular/core';
 import { FeedComponent } from './components/feed/feed/feed.component';
 import { NewPostComponent } from './components/new-post/new-post.component';
+import { HostSessionService } from './services/host-session.service';
 
 @Component({
   selector: 'app-root',
@@ -8,17 +9,28 @@ import { NewPostComponent } from './components/new-post/new-post.component';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit, AfterViewInit {
-  ngAfterViewInit(): void {
-  }
-  ngOnInit(): void {
-  }
-  title = 'redact-feed';
-
+  
   @ViewChild(FeedComponent)
   public feedComponent!: FeedComponent;
 
   @ViewChild(NewPostComponent)
   public newPostComponent!: NewPostComponent;
+
+  title = 'redact-feed';
+  sessionToken = localStorage.getItem('feed.redact.sessionAuthorizationToken');
+  
+  constructor(private hostSessionService: HostSessionService) {}
+
+  ngOnInit(): void {
+    if (this.sessionToken == null) {
+      this.hostSessionService.getSessionToken().then(result => {
+        this.sessionToken = result;
+      });
+    }
+  }
+
+  ngAfterViewInit(): void {
+  }
 
   @HostListener('window:message', ['$event'])
   PostSubmittedEvent(event: MessageEvent) {

--- a/src/app/components/feed/user-post/user-post.component.ts
+++ b/src/app/components/feed/user-post/user-post.component.ts
@@ -34,7 +34,7 @@ export class UserPostComponent implements OnInit {
   }
 
   onEditClicked(){
-    this.queryParams = this.queryParams.append('create', 'true');
+    this.queryParams = this.queryParams.append('edit', 'true');
     this.queryParams = this.queryParams.append('data_type', 'String');
     this.retrievalURL = this.generateRetrievalUrl();
   }

--- a/src/app/components/new-post/new-post.component.ts
+++ b/src/app/components/new-post/new-post.component.ts
@@ -30,6 +30,7 @@ export class NewPostComponent implements OnInit {
     let params = new HttpParams()
       .set("edit",true)
       .set("relay_url", this.appConfigService.relayUrl)
+      .set("css", "input.text{height:40px;width:640px;}iframe{border:none;height:86px;width:700;position:absolute;}body{margin:0px;}")
     return `${this.appConfigService.clientHost}/data/.redact.redact-feed.post.${newPostUuid}.?${params.toString()}`;
   }
 }

--- a/src/app/components/new-post/new-post.component.ts
+++ b/src/app/components/new-post/new-post.component.ts
@@ -28,9 +28,7 @@ export class NewPostComponent implements OnInit {
   private generatePostUrl() {
     const newPostUuid = uuid.v4();
     let params = new HttpParams()
-      .set("create",true)
-      .set("data_type", "String")
-      .set("css", "input.text{height:40px;width:700px;}iframe{border:none;height:86px;width:700;position:absolute;}body{margin:0px;}")
+      .set("edit",true)
       .set("relay_url", this.appConfigService.relayUrl)
     return `${this.appConfigService.clientHost}/data/.redact.redact-feed.post.${newPostUuid}.?${params.toString()}`;
   }

--- a/src/app/models/api/jwt-token-response.model.ts
+++ b/src/app/models/api/jwt-token-response.model.ts
@@ -1,0 +1,3 @@
+export interface JwtResponse {
+    auth_token: string
+}

--- a/src/app/services/appconfig.service.ts
+++ b/src/app/services/appconfig.service.ts
@@ -32,4 +32,8 @@ export class AppConfigService {
   get apiHost() : string {
     return this.appConfig.apiHost;
   }
+
+  get sessionCreateUrl() : string {
+    return this.appConfig.sessionCreateUrl;
+  }
 }

--- a/src/app/services/feed.service.ts
+++ b/src/app/services/feed.service.ts
@@ -1,8 +1,10 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { from, Observable } from 'rxjs';
 import { Post } from '../models/api/post.model';
 import { AppConfigService } from './appconfig.service';
+import { HostSessionService } from './host-session.service';
+import { mergeMap } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -11,13 +13,17 @@ export class FeedService {
 
   constructor(
     private http: HttpClient,
-    private appConfigService: AppConfigService
+    private appConfigService: AppConfigService,
+    private hostSessionService: HostSessionService
   ) { }
 
   getPosts(): Observable<Post[]> {
-    let jwtToken = localStorage.getItem('feed.redact.sessionAuthorizationToken');
-    let headers = new HttpHeaders()
-      .set('Authorization', `Bearer ${jwtToken}`);
-    return this.http.get<Post[]>(`${this.appConfigService.apiHost}/feed`, {headers});
+    return from(this.hostSessionService.getSessionToken())
+    .pipe(
+      mergeMap((jwt: string) => {
+        let headers = new HttpHeaders()
+          .set('Authorization', `Bearer ${jwt}`);
+        return this.http.get<Post[]>(`${this.appConfigService.apiHost}/feed`, {headers});
+      }))
   }
 }

--- a/src/app/services/feed.service.ts
+++ b/src/app/services/feed.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Post } from '../models/api/post.model';
@@ -15,6 +15,9 @@ export class FeedService {
   ) { }
 
   getPosts(): Observable<Post[]> {
-    return this.http.get<Post[]>(`${this.appConfigService.apiHost}/feed/abc`);
+    let jwtToken = localStorage.getItem('feed.redact.sessionAuthorizationToken');
+    let headers = new HttpHeaders()
+      .set('Authorization', `Bearer ${jwtToken}`);
+    return this.http.get<Post[]>(`${this.appConfigService.apiHost}/feed`, {headers});
   }
 }

--- a/src/app/services/host-session.service.spec.ts
+++ b/src/app/services/host-session.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HostSessionService } from './host-session.service';
+
+describe('HostSessionService', () => {
+  let service: HostSessionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(HostSessionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/host-session.service.ts
+++ b/src/app/services/host-session.service.ts
@@ -1,0 +1,45 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { JwtHelperService } from '@auth0/angular-jwt';
+import { Observable } from 'rxjs';
+import { JwtResponse } from '../models/api/jwt-token-response.model';
+import { AppConfigService } from './appconfig.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HostSessionService {
+
+  jwtHelperService: JwtHelperService;
+
+  constructor(
+    private http: HttpClient,
+    private appConfigService: AppConfigService
+  ) { 
+    this.jwtHelperService = new JwtHelperService();
+  }
+
+  getSessionToken(): Promise<string> {
+    let isValid = false;
+    let existingToken = localStorage.getItem('feed.redact.sessionAuthorizationToken');
+    if (existingToken != null && this.jwtHelperService.getTokenExpirationDate(existingToken as string) != null) {
+      isValid = (this.jwtHelperService.getTokenExpirationDate(existingToken as string) as Date) < new Date(Date.now());
+      if (isValid) {
+        return new Promise(resolve => resolve(existingToken as string));
+      }
+    }
+
+    return new Promise(resolve => {
+      this.http.post<JwtResponse>(
+        `${this.appConfigService.clientHost}/proxy`,
+        { 
+          host_url: this.appConfigService.sessionCreateUrl
+        }
+      ).subscribe(
+          (data: JwtResponse) => {
+            localStorage.setItem('feed.redact.sessionAuthorizationToken', data.auth_token);
+            resolve(data.auth_token);
+       })
+    });
+  }
+}

--- a/src/app/services/host-session.service.ts
+++ b/src/app/services/host-session.service.ts
@@ -23,7 +23,7 @@ export class HostSessionService {
     let isValid = false;
     let existingToken = localStorage.getItem('feed.redact.sessionAuthorizationToken');
     if (existingToken != null && this.jwtHelperService.getTokenExpirationDate(existingToken as string) != null) {
-      isValid = (this.jwtHelperService.getTokenExpirationDate(existingToken as string) as Date) < new Date(Date.now());
+      isValid = (this.jwtHelperService.getTokenExpirationDate(existingToken as string) as Date) > new Date(Date.now());
       if (isValid) {
         return new Promise(resolve => resolve(existingToken as string));
       }

--- a/src/assets/config/app-config.json
+++ b/src/assets/config/app-config.json
@@ -1,5 +1,6 @@
 {
-    "apiHost": "http://localhost:5000",
-    "relayUrl": "http://localhost:5000/redact/relay",
+    "apiHost": "https://redact-feed-api.dev.pauwelslabs.com",
+    "relayUrl": "https://redact-feed-api.dev.pauwelslabs.com/redact/relay",
+    "sessionCreateUrl": "https://redact-feed-api.dev.pauwelslabs.com/redact/session_create",
     "clientHost": "http://localhost:8080"
   }


### PR DESCRIPTION
Using a JWT to identify the current user.

In order to request the list of posts from the feed API, the UI needs to be able to identify which user the request is from.  The Feed API uses is a hash of the user's Redact Client (self-signed) certificate to uniquely identify users.  The UI retrieves this user ID by making a request to client, which instructs the client to request a JWT from the Feed API.  The Feed API connects to the client with mutual TLS, generates the user ID by hashing the client certificate, and responds with a JWT which has the user ID in the payload.  This JWT is then passed back to the UI, which can use the token to make a GET request for posts for the current user (or more specifically, the Redact client certificate)